### PR TITLE
Feat/achal/#75/highlight text edit

### DIFF
--- a/client/src/assets/styles/TranscriptionSection.css
+++ b/client/src/assets/styles/TranscriptionSection.css
@@ -48,6 +48,25 @@
     line-height: 1.5;
   }
   
+  /* Highlighted text styling */
+  .highlighted-text {
+    padding: 2px 4px;
+    border-radius: 3px;
+    display: inline;
+  }
+  
+  /* Edit mode styling */
+  .transcription-text textarea {
+    font-family: inherit;
+    font-size: 0.875rem;
+    color: #e2e8f0;
+    line-height: 1.5;
+  }
+  
+  .transcription-text textarea:focus {
+    outline: none;
+  }
+  
   .transcription-actions {
     display: flex;
     justify-content: flex-end;

--- a/client/src/assets/styles/TranscriptionSection.css
+++ b/client/src/assets/styles/TranscriptionSection.css
@@ -20,6 +20,26 @@
   .transcription-text {
     flex: 1;
     overflow-y: auto;
+    max-height: 37.5rem; /* 600px - equivalent to max-h-[600px] */
+  }
+  
+  /* Custom scrollbar styling for better visibility */
+  .transcription-text::-webkit-scrollbar {
+    width: 8px;
+  }
+  
+  .transcription-text::-webkit-scrollbar-track {
+    background: #475569; /* slate-600 */
+    border-radius: 4px;
+  }
+  
+  .transcription-text::-webkit-scrollbar-thumb {
+    background: #64748b; /* slate-500 */
+    border-radius: 4px;
+  }
+  
+  .transcription-text::-webkit-scrollbar-thumb:hover {
+    background: #94a3b8; /* slate-400 */
   }
   
   .transcription-text p {

--- a/client/src/components/TranscriptionSection.jsx
+++ b/client/src/components/TranscriptionSection.jsx
@@ -26,6 +26,10 @@ const TranscriptionSection = ({ transcriptionData, onTranscriptionUploaded }) =>
     const [selectedTranscriptionText, setSelectedTranscriptionText] = useState("");
     const [loading, setLoading] = useState(false);
     const [deleting, setDeleting] = useState(false);
+    const [isEditing, setIsEditing] = useState(false);
+    const [editedText, setEditedText] = useState("");
+    const [saving, setSaving] = useState(false);
+    const [highlightColor, setHighlightColor] = useState("yellow");
     const previousProjectId = useRef(activeProjectId);
     const previousTranscriptionData = useRef(transcriptionData);
 
@@ -160,6 +164,8 @@ const TranscriptionSection = ({ transcriptionData, onTranscriptionUploaded }) =>
                     // Clear selection
                     setSelectedTranscriptionId(null);
                     setSelectedTranscriptionText("");
+                    setEditedText("");
+                    setIsEditing(false);
                 }
                 console.log('Transcription deleted successfully');
             } else {
@@ -173,6 +179,83 @@ const TranscriptionSection = ({ transcriptionData, onTranscriptionUploaded }) =>
         } finally {
             setDeleting(false);
         }
+    };
+
+    // Handle edit mode toggle
+    const handleEditToggle = () => {
+        if (isEditing) {
+            // Cancel editing
+            setEditedText("");
+            setIsEditing(false);
+        } else {
+            // Start editing
+            setEditedText(selectedTranscriptionText);
+            setIsEditing(true);
+        }
+    };
+
+    // Handle save transcription
+    const handleSaveTranscription = async () => {
+        if (!selectedTranscriptionId || !activeProjectId || !editedText.trim()) return;
+        
+        try {
+            setSaving(true);
+            const response = await fetch(
+                API_ENDPOINTS.updateProjectTranscription(activeProjectId, selectedTranscriptionId),
+                {
+                    method: 'PUT',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({ text: editedText }),
+                }
+            );
+            
+            if (response.ok) {
+                setSelectedTranscriptionText(editedText);
+                setIsEditing(false);
+                setEditedText("");
+                console.log('Transcription saved successfully');
+            } else {
+                const errorData = await response.json();
+                console.error('Failed to save transcription:', errorData);
+                alert('Failed to save transcription. Please try again.');
+            }
+        } catch (error) {
+            console.error('Error saving transcription:', error);
+            alert('An error occurred while saving the transcription. Please try again.');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    // Handle text highlighting
+    const handleHighlightText = () => {
+        const selection = window.getSelection();
+        if (selection.toString().trim()) {
+            const range = selection.getRangeAt(0);
+            const span = document.createElement('span');
+            span.style.backgroundColor = highlightColor;
+            span.style.padding = '2px 4px';
+            span.style.borderRadius = '3px';
+            span.className = 'highlighted-text';
+            
+            try {
+                range.surroundContents(span);
+                selection.removeAllRanges();
+            } catch (e) {
+                // If surroundContents fails, try a different approach
+                const contents = range.extractContents();
+                span.appendChild(contents);
+                range.insertNode(span);
+                selection.removeAllRanges();
+            }
+        }
+    };
+
+    // Handle highlight color change
+    const handleHighlightColorChange = (color) => {
+        setHighlightColor(color);
     };
 
     const handleDownloadTranscription = async () => { // Make the function async
@@ -271,15 +354,46 @@ const TranscriptionSection = ({ transcriptionData, onTranscriptionUploaded }) =>
 
                 {/* Action buttons container */}
                 <div className='flex gap-3'>
-                    {/* Edit transcription button */}
+                    {/* Edit/Save transcription button */}
                     <button
-                        className="bg-indigo-600 text-white text-sm px-4 py-2 rounded-md hover:bg-indigo-700 flex items-center gap-2"
-                        aria-label="Edit transcription"
-                    // onClick={editTranscription} 
-                    // TODO: Implement transcription editing functionality
+                        className={`text-white text-sm px-4 py-2 rounded-md flex items-center gap-2 ${
+                            isEditing 
+                                ? "bg-green-600 hover:bg-green-700" 
+                                : "bg-indigo-600 hover:bg-indigo-700"
+                        }`}
+                        aria-label={isEditing ? "Save transcription" : "Edit transcription"}
+                        onClick={isEditing ? handleSaveTranscription : handleEditToggle}
+                        disabled={!selectedTranscriptionId || saving}
                     >
-                        <i className="bi bi-pencil" aria-hidden="true" />
+                        {saving ? (
+                            <>
+                                <i className="bi bi-arrow-clockwise spin" aria-hidden="true" />
+                                Saving...
+                            </>
+                        ) : isEditing ? (
+                            <>
+                                <i className="bi bi-check" aria-hidden="true" />
+                                Save
+                            </>
+                        ) : (
+                            <>
+                                <i className="bi bi-pencil" aria-hidden="true" />
+                                Edit
+                            </>
+                        )}
                     </button>
+
+                    {/* Cancel edit button - only show when editing */}
+                    {isEditing && (
+                        <button
+                            className="bg-gray-600 text-white text-sm px-4 py-2 rounded-md hover:bg-gray-700 flex items-center gap-2"
+                            aria-label="Cancel editing"
+                            onClick={handleEditToggle}
+                        >
+                            <i className="bi bi-x" aria-hidden="true" />
+                            Cancel
+                        </button>
+                    )}
 
                     {/* Delete transcription button */}
                     <button
@@ -315,12 +429,49 @@ const TranscriptionSection = ({ transcriptionData, onTranscriptionUploaded }) =>
 
             {/* Transcription content area */}
             <div className="bg-slate-700 rounded-lg p-3 flex-1 flex flex-col min-h-0">
+                {/* Highlighting toolbar - only show when not editing */}
+                {!isEditing && selectedTranscriptionId && (
+                    <div className="flex items-center gap-2 mb-2 pb-2 border-b border-slate-600">
+                        <span className="text-xs text-slate-400">Highlight:</span>
+                        <div className="flex gap-1">
+                            {['yellow', 'lightblue', 'lightgreen', 'pink', 'orange'].map((color) => (
+                                <button
+                                    key={color}
+                                    className={`w-4 h-4 rounded border-2 ${
+                                        highlightColor === color ? 'border-white' : 'border-slate-500'
+                                    }`}
+                                    style={{ backgroundColor: color }}
+                                    onClick={() => handleHighlightColorChange(color)}
+                                    aria-label={`Select ${color} highlight color`}
+                                />
+                            ))}
+                        </div>
+                        <button
+                            className="bg-transparent border-0 text-slate-400 cursor-pointer p-1 ml-2 transition-colors hover:text-slate-200"
+                            aria-label="Highlight selected text"
+                            onClick={handleHighlightText}
+                        >
+                            <i className="bi bi-highlighter" aria-hidden="true"></i>
+                        </button>
+                    </div>
+                )}
+
                 {/* Scrollable transcription text container */}
                 <div className="flex-1 overflow-y-auto max-h-[200px] transcription-text">
-                    {/* Placeholder transcription text - will be replaced with actual content */}
-                    <p className="text-sm text-gray-300 leading-6 whitespace-pre-wrap">
-                        {displayText}
-                    </p>
+                    {isEditing ? (
+                        <textarea
+                            className="w-full h-full bg-transparent text-sm text-gray-300 leading-6 resize-none border-none outline-none"
+                            value={editedText}
+                            onChange={(e) => setEditedText(e.target.value)}
+                            placeholder="Edit transcription text here..."
+                        />
+                    ) : (
+                        <div 
+                            className="text-sm text-gray-300 leading-6 whitespace-pre-wrap"
+                            contentEditable={false}
+                            dangerouslySetInnerHTML={{ __html: displayText.replace(/\n/g, '<br>') }}
+                        />
+                    )}
                 </div>
 
                 {/* Transcription toolbar (bottom right) */}
@@ -332,15 +483,6 @@ const TranscriptionSection = ({ transcriptionData, onTranscriptionUploaded }) =>
                     // TODO: Implement code view toggle functionality
                     >
                         <i className="bi bi-code" aria-hidden="true"></i>
-                    </button>
-
-                    {/* Highlighting tool button */}
-                    <button
-                        className="bg-transparent border-0 text-slate-400 cursor-pointer p-1 ml-2 transition-colors hover:text-slate-200"
-                        aria-label="Highlight text"
-                    // TODO: Implement text highlighting functionality
-                    >
-                        <i className="bi bi-highlighter" aria-hidden="true"></i>
                     </button>
                 </div>
             </div>

--- a/client/src/components/TranscriptionSection.jsx
+++ b/client/src/components/TranscriptionSection.jsx
@@ -6,6 +6,7 @@
 import React, { useState, useEffect, useRef } from 'react'; // Make sure React is imported
 import { API_ENDPOINTS } from "../config/api";
 import { useProject } from "../contexts/ProjectContext";
+import "../assets/styles/TranscriptionSection.css";
 
 
 /** Safely parse JSON, returns null on failure */
@@ -242,7 +243,8 @@ const TranscriptionSection = ({ transcriptionData, onTranscriptionUploaded }) =>
 
     return (
         /* Main container with card styling and flex layout */
-        <div className="bg-slate-800 rounded-xl shadow-md p-4 flex-1 flex flex-col">
+        <div className="bg-slate-800 rounded-xl shadow-md p-4 flex-1 flex flex-col min-h-0 overflow-hidden">
+
             {/* Header section with title and action buttons */}
             <div className="flex justify-between items-center mb-2 font-sora">
                 {/* Section title with dropdown */}
@@ -312,11 +314,11 @@ const TranscriptionSection = ({ transcriptionData, onTranscriptionUploaded }) =>
             </div>
 
             {/* Transcription content area */}
-            <div className="bg-slate-700 rounded-lg p-3 flex-1 flex flex-col">
+            <div className="bg-slate-700 rounded-lg p-3 flex-1 flex flex-col min-h-0">
                 {/* Scrollable transcription text container */}
-                <div className="flex-1 overflow-y-auto">
+                <div className="flex-1 overflow-y-auto max-h-[200px] transcription-text">
                     {/* Placeholder transcription text - will be replaced with actual content */}
-                    <p className="text-sm text-gray-300 leading-6">
+                    <p className="text-sm text-gray-300 leading-6 whitespace-pre-wrap">
                         {displayText}
                     </p>
                 </div>

--- a/client/src/config/api.jsx
+++ b/client/src/config/api.jsx
@@ -9,5 +9,6 @@ export const API_ENDPOINTS = {
 
   listProjectTranscriptions: (projectId) => `${API_BASE}/projects/${projectId}/transcriptions`,
   getProjectTranscription: (projectId, transcriptionId) => `${API_BASE}/projects/${projectId}/transcriptions/${transcriptionId}`,
+  updateProjectTranscription: (projectId, transcriptionId) => `${API_BASE}/projects/${projectId}/transcriptions/${transcriptionId}`,
   deleteProjectTranscription: (projectId, transcriptionId) => `${API_BASE}/projects/${projectId}/transcriptions/${transcriptionId}`
 };

--- a/server/app/api_models.py
+++ b/server/app/api_models.py
@@ -11,6 +11,9 @@ class Transcription(BaseModel):
     name: str
     text: str
 
+class TranscriptionUpdate(BaseModel):
+    text: str
+
 
 # === Prompt Management ===
 

--- a/server/app/database_models.py
+++ b/server/app/database_models.py
@@ -271,6 +271,39 @@ class Transcription:
             transcriptions = cur.fetchall()
 
         return transcriptions
+
+    def update(self, transcription_id: int, transcription_text: str) -> bool:
+        """
+        Method to update transcription text by its id.
+
+        Args:
+            transcription_id (int): The id of the transcription to update
+            transcription_text (str): The new transcription text
+
+        Returns:
+            bool: True if update was successful, False otherwise
+
+        Raises:
+            ValueError: If there is no row associated with the transcription id
+        """
+        rows_updated = 0
+
+        with sqlite3.connect(self.db_name) as conn:
+            cur = conn.cursor()
+            cur.execute("PRAGMA foreign_keys = ON;")
+
+            cur.execute(f"""
+                UPDATE {TRANS_TABLE_NAME}
+                SET transcription = ?, processed_at = CURRENT_TIMESTAMP
+                WHERE transcription_id = ?
+            """, (transcription_text, transcription_id))
+
+            rows_updated = cur.rowcount
+
+        if rows_updated < 1:
+            raise ValueError("There is no row associated with this transcription id!")
+
+        return True
     
 if __name__ == "__main__":
     project_manager = Project("qualAI_test.db")

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -277,6 +277,63 @@ def get_transcription(project_id: int, transcription_id: int) -> Dict:
         raise HTTPException(status_code=404, detail="Transcription not found")
 
 
+@app.put("/projects/{project_id}/transcriptions/{transcription_id}")
+def update_transcription(project_id: int, transcription_id: int, payload: api_models.TranscriptionUpdate):
+    """
+    Update a specific transcription by project and transcription ID.
+    """
+    # Ensure project exists
+    try:
+        project_name, _, _ = app.state.projects_store.get_project_by_id(
+            project_id)
+    except LookupError:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    # Get the transcription first to verify it exists and belongs to the project
+    try:
+        proj_id, name, text, processed_at = app.state.transcripts_store.get_transcription_by_id(
+            transcription_id)
+
+        # Verify the transcription belongs to the specified project
+        if proj_id != project_id:
+            raise HTTPException(
+                status_code=404, detail="Transcription not found in this project")
+    except LookupError:
+        raise HTTPException(status_code=404, detail="Transcription not found")
+
+    # Update the transcription in the database
+    try:
+        app.state.transcripts_store.update(transcription_id, payload.text)
+        print(
+            f"Updated transcription {transcription_id} in project {project_id}")
+
+        # Update the vector database with the new content
+        try:
+            app.state.qdrant_manager.clear_collection(project_name)
+            app.state.qdrant_manager.ingest_from_text(project_name, payload.text)
+            print(f"Updated vector database for project: {project_name}")
+        except Exception as vector_error:
+            print(
+                f"Warning: Failed to update vector database for project '{project_name}': {vector_error}")
+            # Don't fail the entire operation if vector update fails
+
+        # Return the updated transcription
+        proj_id, name, text, processed_at = app.state.transcripts_store.get_transcription_by_id(
+            transcription_id)
+        return {
+            "transcription_id": transcription_id,
+            "project_id": proj_id,
+            "name": name,
+            "text": text,
+            "processed_at": processed_at,
+        }
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        raise HTTPException(
+            status_code=500, detail=f"Failed to update transcription: {e}")
+
+
 @app.delete("/projects/{project_id}/transcriptions/{transcription_id}")
 def delete_transcription(project_id: int, transcription_id: int):
     """


### PR DESCRIPTION
# Task
Resolves #75 

# Root Cause
Not being able to edit and save transcripts manually, as well as highlight the transcript.

# Solution 
* added a scroll bar to the transcription component to avoid the overflow of long transcripts
* added the ability to edit transcripts
* edits can be saved to database so they remain persistent upon refresh
* ability to highlight text
* started implementing highlights to increase weightage within vector DB

# How Has This Been Tested? 
1. docker compose down
2. docker compose build
3. docker compose up
4. upload audio file
5. check if edits and highlights can be made
6. refresh to see if changes persist

# Checklist: 
- [ ] I have linked issue to this Pull Request 
- [ ] I have performed a self-review of my code 
- [ ] I have commented my code, particularly in hard-to-understand areas 
- [ ] I have made corresponding changes to the documentation 
- [ ] I have added tests that prove my fix is effective or that my feature works 
- [ ] New and existing unit tests pass locally with my changes
